### PR TITLE
Refactor code according to conventions

### DIFF
--- a/src/commands/generate.c
+++ b/src/commands/generate.c
@@ -102,7 +102,7 @@ char *get_language_standard(char *language) {
         char *answers[] = {"90", "99", "11", "17", "23"};
         OPTIONS options = {.suffix = ""};
         options.prefix = "C";
-        options.help = "if you are not sure, select C11";
+        options.help = "if you are not sure, select C17"; // C17 is a bugfix of C11, there is no reason to not use it
         options.default_index = 2;
         return choose("Choose C standard", answers, 5, &options);
     } else if (strcmp(language, "CXX") == 0) {

--- a/src/helpers/string_funcs.c
+++ b/src/helpers/string_funcs.c
@@ -4,7 +4,7 @@
 #include "alloc.h"
 
 char *trim_string(const char *string) {
-    char *new = alloc(malloc(strlen(string) + 1));
+    char *new = alloc(calloc(strlen(string) + 1, sizeof(char)));
     memset(new, 0, sizeof(string));
 
     int i;
@@ -19,8 +19,7 @@ char *trim_string(const char *string) {
 }
 
 char *get_last_split_item(const char *string, char split, int max_size) {
-    char *item = alloc(malloc(sizeof(char) * max_size));
-    memset(item, 0, sizeof(char) * max_size);
+    char *item = alloc(calloc(max_size, sizeof(char)));
 
     for (int i = 0; i < strlen(string); i++) {
         if (string[i] == split) {

--- a/src/main.c
+++ b/src/main.c
@@ -21,8 +21,7 @@ int main(int argc, char **argv) {
         return EXIT_SUCCESS;
     }
 
-    char *command = alloc(malloc(sizeof(char) * 64));
-    memset(command, 0, 64);
+    char *command = alloc(calloc(64, sizeof(char)));
     strcat(command, argv[1]);
 
     if (strcmp(command, "i") == 0 || strcmp(command, "init") == 0) {
@@ -31,7 +30,7 @@ int main(int argc, char **argv) {
     else if (strcmp(command, "n") == 0 || strcmp(command, "new") == 0) {
         new_project(NULL);
     }
-    else if (strcmp(command, "b") == 0 || strcmp(command, "build") == 0) {
+    else if (!strcmp(command, "b") || !strcmp(command, "build")) {
         build();
     }
     else {

--- a/src/utils/cmake_get.c
+++ b/src/utils/cmake_get.c
@@ -15,7 +15,7 @@ char *cmake_get(char *key) {
     int key_index = 0;
     bool record = false;
     char ch;
-    char *value = alloc(malloc(sizeof(char) * 1024));
+    char *value = alloc(calloc(1024, sizeof(char)));
     memset(value, 0, 1024);
     while ((ch = (char) fgetc(cmake_file)) != EOF) {
         if (record && ch != '(' && ch != ')') {

--- a/src/utils/term.c
+++ b/src/utils/term.c
@@ -165,7 +165,7 @@ char *choose(char *question, char *answers[], int answer_count, OPTIONS *options
 
     unfuck_terminal();
 
-    char *heap_answer = alloc(malloc(sizeof(char) * (strlen(answers[current]) + 1)));
+    char *heap_answer = alloc(calloc((strlen(answers[current]) + 1), sizeof(char)));
     memset(heap_answer, 0, strlen(answers[current]) + 1);
     strcpy(heap_answer, answers[current]);
     return heap_answer;


### PR DESCRIPTION
Changes all occurrences of
```c
alloc(malloc(sizeof(x) * y));
memset(x, 0, y);
```
to
```c
calloc(y, sizeof(x));
```
(those two things are equivalent: [explanation](https://www.tutorialspoint.com/c_standard_library/c_function_calloc.htm#:~:text=The%20C%20library%20function%20void,sets%20allocated%20memory%20to%20zero.))